### PR TITLE
Update workflows to run on v* branches

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   publish-previews:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   publish-releases:


### PR DESCRIPTION
## Motivation
We're moving away from `master` branch names and using `v*` format instead.

## Approach
- Changed default branch to `v0`
- Updated workflows to run on `v[0-9]+`