### PR TITLE
Remove typescript and eslint from eslint-config's dependencies

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
-    "eslint-plugin-prefer-let": "^1.0.0"
+    "eslint-plugin-prefer-let": "^1.0.1"
   },
   "peerDependencies": {
     "eslint": ">=3"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,10 +13,9 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
-    "eslint-plugin-prefer-let": "^1.0.1"
+    "eslint-plugin-prefer-let": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "*",
-    "typescript": "*"
+    "eslint": ">=3"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
-    "eslint-plugin-prefer-let": "^1.0.1"
+    "eslint-plugin-prefer-let": "^1.0.2"
   },
   "peerDependencies": {
     "eslint": ">=3"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/eslint-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Shared eslint config @thefrontside",
   "main": "index.js",
   "author": "Frontside Engineering <engineering@frontside.com>",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,5 +14,9 @@
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
     "eslint-plugin-prefer-let": "^1.0.1"
+  },
+  "peerDependencies": {
+    "eslint": "*",
+    "typescript": "*"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,8 +13,6 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
-    "eslint": "^7.3.1",
-    "eslint-plugin-prefer-let": "^1.0.1",
-    "typescript": "^3.9.5"
+    "eslint-plugin-prefer-let": "^1.0.1"
   }
 }

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -1,7 +1,6 @@
 {
   "name": "eslint-plugin-prefer-let",
-  "version": "1.0.0",
-  "private": true,
+  "version": "1.0.1",
   "description": "Rule to prefer using `let` to bind names to values",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-prefer-let",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Rule to prefer using `let` to bind names to values",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eslint-plugin-prefer-let",
   "version": "1.0.0",
+  "private": true,
   "description": "Rule to prefer using `let` to bind names to values",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@frontside/eslint-plugin-prefer-let",
+  "name": "eslint-plugin-prefer-let",
   "version": "1.0.0",
   "description": "Rule to prefer using `let` to bind names to values",
   "keywords": [


### PR DESCRIPTION
## Motivation
In the process of learning how ESLint works and getting `eslint-config` to work, I was too quick to add a bunch of dependencies that may not be necessary for `frontside/eslint-config`.

## Approach
- Removed `typescript` and `eslint` from `eslint-config`'s dependencies.
- Kept `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, and `eslint-plugin-prefer-let`.

It is my understanding that we need only the dependencies that are relevant to `eslint-config` so I should not have added `typescript` and `eslint` as those are things that people should add to their projects manually. It wouldn't make sense to install `eslint-config` but not `eslint`.