### PR TITLE
Introduce @frontside/typescript

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@frontside/eslint-config": "1.1.1",
     "@frontside/tsconfig": "1.0.0",
+    "eslint": "7.4.0",
     "typescript": "3.9.6"
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@frontside/typescript",
+  "version": "1.0.0",
+  "description": "Frontside Typescript",
+  "author": "Frontside Engineering <engineering@frontside.com>",
+  "dependencies": {
+    "@frontside/eslint-config": "1.1.1",
+    "@frontside/tsconfig": "1.0.0",
+    "typescript": "3.9.6"
+  }
+}

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontside/typescript",
   "version": "1.0.0",
-  "description": "Frontside Typescript",
+  "description": "TypeScript Development Tools at Frontside",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "dependencies": {
     "@frontside/eslint-config": "1.1.1",


### PR DESCRIPTION
## Motivation
Instead of having to install `eslint`, `typescript`, `@frontside/tsconfig`, AND `@frontside/eslint-config`, you can just install `@frontside/typescript` and it's all there for you.