### PR TITLE
New eslint rules

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -9,9 +9,18 @@ module.exports = {
   ],
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-use-before-define": "off",
+    "arrow-spacing": "error",
+    "eol-last": "error",
+    "no-empty-function": "off",
+    "no-multi-spaces": "error",
+    "no-trailing-spaces": "error",
+    "object-curly-spacing": ["error", "always"],
+    "one-var": ["error", { initialized: "never" }],
     "prefer-const": "off",
     "prefer-let/prefer-let": "error",
+    semi: ["error", "always", { omitLastInOneLineBlock: true }],
   }
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -8,10 +8,10 @@ module.exports = {
     "@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-use-before-define": "off",
     "prefer-const": "off",
     "prefer-let/prefer-let": "error",
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-unused-vars": "error"
   }
 }


### PR DESCRIPTION
## Motivation

Our current eslint config is unopinionated about whitespace and semicolons, and I am. Seeing diffs that add whitespace at the end of lines or the removal of a newline character at the end of a file drives me a little nuts. Just a little bit.

## Approach

- Sort the rules alphabetically
- Add the following rules:
  - `"@typescript-eslint/no-empty-function": "off"`: No-op functions are fairly common and in my experience this rule does not add value, only annoyance due to needing to put a `return` or a comment in no-ops.
  - `"arrow-spacing": "error"`: Adds whitespace around arrows for tidy, consistent formatting.
  - `"eol-last": "error"`: I'm not sure if this is technically required still, but having a newline at the end of a file is at least traditional and github complains at you in the diff view if you don't include a newline.
  - `"no-empty-function": "off"`: This is necessary for `"@typescript-eslint/no-empty-function": "off"` to work.
  - `"no-multi-spaces": "error"`: Eliminates multiple consecutive spaces where you only need one for the sake of tidy, consistent formatting.
  - `"no-trailing-spaces": "error"`: Eliminates trailing spaces at the end of a line. This is for tidiness as well, and it's very minor because you can only see it in a diff, but it's also auto-fixable, so I was inclined to include it.
  - `"object-curly-spacing": ["error", "always"]`: Adds whitespace padding inside object curlies for tidiness and consistency. It's easier on the eyes to parse objects when they have this whitespace, especially if there are multiple levels of curlies.
  - `"one-var": ["error", { initialized: "never" }]`: This allows `let foo, bar;` but disallows `let foo = 1, bar = 2;`. These initializations are usually spread across multiple lines and can be easily confused with a variable reassignment if you miss the `let` or `const` multiple lines up.
  - `semi: ["error", "always", { omitLastInOneLineBlock: true }]`: Enforces a semicolon usage, but allows one-line blocks to omit the semicolon (`element => { element.click() }`). This is for consistency and tidiness. I am not dogmatic about semis vs. no-semis and would be (almost) as happy enforcing no semis.