### PR TITLE
Disallow `only` in mocha tests

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -4,6 +4,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended"
   ],
   "plugins": [
+    "mocha-no-only",
     "prefer-let",
     "@typescript-eslint"
   ],
@@ -14,6 +15,7 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": "off",
     "arrow-spacing": "error",
     "eol-last": "error",
+    "mocha-no-only/mocha-no-only": ["error"],
     "no-empty-function": "off",
     "no-multi-spaces": "error",
     "no-trailing-spaces": "error",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
-    "eslint-plugin-prefer-let": "^1.1.0"
+    "eslint-plugin-prefer-let": "^1.1.0",
+    "eslint-plugin-mocha-no-only": "^1.1.1"
   },
   "scripts": {
     "test": "echo No test for @frontside/eslint-config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -458,6 +458,13 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-plugin-mocha-no-only@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha-no-only/-/eslint-plugin-mocha-no-only-1.1.1.tgz#2da56949776e8c5455cfeb67f2747d2d8cf522fc"
+  integrity sha512-b+vgjJQ3SjRQCygBhomtjzvRQRpIP8Yd9cqwNSbcoVJREuNajao7M1Kl1aObAUc4wx98qsZyQyUSUxiAbMS9yA==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
@@ -1189,6 +1196,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 requireindex@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Disallows accidentally leaving in `only` statements when writing mocha tests.