### PR TITLE
bump version for tsconfig and eslint plugin

### DIFF
--- a/.changeset/perfect-dingos-study.md
+++ b/.changeset/perfect-dingos-study.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-prefer-let": major
+"@frontside/tsconfig": major
+---
+
+Bump version to 3.0

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-prefer-let",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Rule to prefer using `let` to bind names to values",
   "keywords": [
     "eslint",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontside/tsconfig",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Frontside Typescript Config",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "main": "tsconfig.json",


### PR DESCRIPTION
## Motivation

`eslint-plugin-prefer-let` and `@frontside/tsconfig` have unsync versions with v2 main branch

## Approach

Bump versions