### PR TITLE
Add `package.repository` to have link to sources

### DIFF
--- a/.changeset/orange-penguins-provide.md
+++ b/.changeset/orange-penguins-provide.md
@@ -1,0 +1,4 @@
+---
+eslint-plugin-prefer-let: patch
+---
+Add `package.repository` to have link to sources

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -21,5 +21,6 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "repository": " thefrontside/javascript ",
 }

--- a/packages/eslint-plugin-prefer-let/package.json
+++ b/packages/eslint-plugin-prefer-let/package.json
@@ -22,5 +22,5 @@
     "node": ">=0.10.0"
   },
   "license": "ISC",
-  "repository": " thefrontside/javascript ",
+  "repository": "thefrontside/javascript",
 }


### PR DESCRIPTION
## Motivation

It will add link to source code and ChangeLog from npm package page.

It will avoid having questions like https://github.com/cowboyd/eslint-plugin-prefer-let/issues/10#issuecomment-953348078

## Approach

Official way

### Alternate Designs

We can do the direct link, but I started from the simple solution