### PR TITLE
Reduce npm package

### DIFF
--- a/.changeset/cool-ads-thank.md
+++ b/.changeset/cool-ads-thank.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prefer-let": patch
+---
+
+Exclude the docs and tests folder for a slimmer NPM package

--- a/packages/eslint-plugin-prefer-let/.npmignore
+++ b/packages/eslint-plugin-prefer-let/.npmignore
@@ -1,0 +1,2 @@
+docs
+tests


### PR DESCRIPTION
## Motivation

Remove unnecessary files from `node_modules` to save space and make `npm install` faster

## Approach

`npm publish` do not publish files from `.npmignore`.

Other ESLint plugins does the same.

### Alternate Designs

We can also use `package.files`, but I started from the safest solution.