### PR TITLE
add consistent-type-imports to @frontside/eslint-config

### DIFF
--- a/.changeset/consistent-types.md
+++ b/.changeset/consistent-types.md
@@ -1,0 +1,4 @@
+---
+"@frontside/eslint-config": minor
+---
+add [consistent-type-imports](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md) to @frontside/eslint-config

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-unused-vars": "error",


### PR DESCRIPTION
## Motivation

[consistent-type-imports](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/consistent-type-imports.md) can really help to get a bundle size down if you are only importing the types from a package, you won't trigger the loading of a `main` or `module` file.

With this rule and `yarn lint --fix` you should be able to standardise its use throughout a codebase.

## Approach

add the rule.

```ts
import { Simulator, LegacyServiceCreator } from '@simulacrum/server';
```

becomes


```ts
import type { Simulator, LegacyServiceCreator } from '@simulacrum/server';
```


