### PR TITLE
Update preview action source and environment variables

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,14 +10,14 @@ jobs:
     name: Publish Preview Packages
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
         registry-url: https://registry.npmjs.org
     - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@main
+      uses: thefrontside/actions/publish-pr-preview@v2
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
       with:
         npm_publish: yarn publish
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation

This is part of an effort to finalize [@thefrontside/actions #68](https://github.com/thefrontside/actions/issues/68) by moving all actions being called from the `main` branch to move over to `v2`.

## Approach

- Updated action source
- Checkout needed to be upgraded to `v3` too due to [@thefrontside/actions #73](https://github.com/thefrontside/actions/pull/73)
- Replaced npm and github tokens with organization secrets (you can see them [here](https://github.com/thefrontside/javascript/settings/secrets/actions))