### PR TITLE
Support the `using` declaration from explicit resource management

### DIFF
--- a/.changeset/warm-pans-remember.md
+++ b/.changeset/warm-pans-remember.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prefer-let": patch
+---
+
+Support the `using` declaration from explicit resource management

--- a/packages/eslint-plugin-prefer-let/lib/rules/prefer-let.js
+++ b/packages/eslint-plugin-prefer-let/lib/rules/prefer-let.js
@@ -76,7 +76,7 @@ module.exports = {
             message: 'prefer `let` over `var` to declare value bindings',
             node
           });
-        } else if (node.kind !== 'let' && !isTopLevelScope(node)) {
+        } else if (node.kind === 'const' && !isTopLevelScope(node)) {
           let constToken = sourceCode.getFirstToken(node);
 
           context.report({

--- a/packages/eslint-plugin-prefer-let/tests/lib/rules/prefer-let.js
+++ b/packages/eslint-plugin-prefer-let/tests/lib/rules/prefer-let.js
@@ -118,6 +118,6 @@ ruleTester.run("prefer-let", rule, {
         message: "`const` declaration outside top-level scope",
         type: "VariableDeclaration"
       }]
-    }
+    },
   ]
 });


### PR DESCRIPTION
## Motivation

resolves #55 

Typescript added the 'using' keyword: a way to declare a lexical variable and assign ownership of it at the same time.


