### PR TITLE
👷 Setup OIDC publishing

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -37,8 +37,6 @@ jobs:
       - name: covector version or publish (publish when no change files present)
         uses: jbolda/covector/packages/action@covector-v0
         id: covector
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: "version-or-publish"

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # required for use of git history
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          registry-url: "https://registry.npmjs.org"
+          node-version: 24
       - uses: volta-cli/action@v4
       - name: git config
         run: |


### PR DESCRIPTION
## Motivation

Publishing the old way is not an option.

## Approach

- Remove the `registry-url` which is known to be problematic and force `npm` to use an auth token
- Upgrade to setup-node v6 with node v24
- Remove `NPM_TOKEN` secret from the npm environment which would also force token authentication