### PR TITLE
Ignore export const case

### DIFF
--- a/.changes/fix-export-const.md
+++ b/.changes/fix-export-const.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prefer-let": patch
+---
+
+Ignore `export const` cases

--- a/packages/eslint-plugin-prefer-let/lib/rules/prefer-let.js
+++ b/packages/eslint-plugin-prefer-let/lib/rules/prefer-let.js
@@ -132,6 +132,8 @@ module.exports = {
                 }
               });
             }
+          } else if (node.parent && node.parent.type === 'ExportNamedDeclaration') {
+            // ignore `export const` cases
           } else {
             let constToken = sourceCode.getFirstToken(node);
             context.report({


### PR DESCRIPTION
## Motivation

@cowboyd sorry, I came with small fix for my recent PR.

In JS code `let`/`const` is almost identical.

In `export` statement `let` means that export value can be changed in runtime. It is a very different signal.

 I suggest ignoring `export` case at all in the rule.