### PR TITLE
Fix ignoring export const cases

### DIFF
--- a/.changes/fix-export-const2.md
+++ b/.changes/fix-export-const2.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-prefer-let": patch
+---
+
+Fix ignoring `export const` cases

--- a/packages/eslint-plugin-prefer-let/lib/rules/prefer-let.js
+++ b/packages/eslint-plugin-prefer-let/lib/rules/prefer-let.js
@@ -122,7 +122,7 @@ module.exports = {
           });
         } else if (node.kind === 'const') {
           if (isTopLevelScope(node)) {
-            if (forceUpperCaseConst && !allDeclaratorsUpperCase(node)) {
+            if (forceUpperCaseConst && !allDeclaratorsUpperCase(node) && !(node.parent && node.parent.type === 'ExportNamedDeclaration')) {
               let constToken = sourceCode.getFirstToken(node);
               context.report({
                 message: '`const` declaration for non-constant names at top-level scope. Use `let` or rename to UPPER_CASE',

--- a/packages/eslint-plugin-prefer-let/tests/lib/rules/prefer-let.js
+++ b/packages/eslint-plugin-prefer-let/tests/lib/rules/prefer-let.js
@@ -82,6 +82,11 @@ ruleTester.run("prefer-let", rule, {
       code: "export const FOO_BAR = 'baz';",
       options: [{ forceUpperCaseConst: true }]
     },
+    // forceUpperCaseConst: export const with non-upper-case name does not create an issue
+    {
+      code: "export const foo = 'bar';",
+      options: [{ forceUpperCaseConst: true }]
+    },
     // forceUpperCaseConst: let with non-upper-case at top level is valid
     {
       code: "let fooBar = 'baz';",
@@ -149,14 +154,6 @@ ruleTester.run("prefer-let", rule, {
     {
       code: "const { foo, bar } = {};",
       output: "let { foo, bar } = {};",
-      options: [{ forceUpperCaseConst: true }],
-      errors: [{
-        message: "`const` declaration for non-constant names at top-level scope. Use `let` or rename to UPPER_CASE"
-      }]
-    },
-    {
-      code: "export const AlsoObject = Object;",
-      output: "export let AlsoObject = Object;",
       options: [{ forceUpperCaseConst: true }],
       errors: [{
         message: "`const` declaration for non-constant names at top-level scope. Use `let` or rename to UPPER_CASE"


### PR DESCRIPTION
Sorry, I was in a hurry in [previous time](https://github.com/thefrontside/javascript/pull/88) and didn't add proper tests.

Now I fix the issue and add tests.